### PR TITLE
Minified code compatibility

### DIFF
--- a/src/BaseMigration.js
+++ b/src/BaseMigration.js
@@ -47,7 +47,10 @@ export default class BaseMigration {
      * @param transaction
      */
     insertMigrationRow(transaction){
-        transaction.executeSql('INSERT INTO migrations (migration_name) values (?)', [this.constructor.name])
+        transaction.executeSql(
+            'INSERT INTO migrations (migration_name) values (?)',
+            [this.name || this.constructor.name]
+        )
     }
 
     /**

--- a/src/ExpoMigration.js
+++ b/src/ExpoMigration.js
@@ -32,7 +32,7 @@ export default class ExpoMigration {
             this.database.transaction(transaction => {
                     migrations.forEach(migration => {
                         const migrationInstance = new migration();
-                        const migrationName = migrationInstance.constructor.name;
+                        const migrationName = migrationInstance.name || migrationInstance.constructor.name;
                         const alreadyMigrated = this.completedMigrations.some(completedMigration => {
                             return completedMigration.migration_name === migrationName;
                         });


### PR DESCRIPTION
This PR resolves issues where the codebase is minified, meaning that the constructor names of classes could change whenever the code is compiled.

To resolve this I've added a check for `name` property on a migration before using the constructor name.

This has come up when originally testing an Expo application in development mode, then when switching to production mode Expo then minifies the code.